### PR TITLE
Fix the missing window icon when running under Wayland

### DIFF
--- a/gui_source/main_gui.cpp
+++ b/gui_source/main_gui.cpp
@@ -49,6 +49,10 @@ int main(int argc, char *argv[])
 
     QApplication a(argc, argv);
 
+#ifdef Q_OS_LINUX
+    a.setDesktopFileName("xocalc");
+#endif
+
     XOptions xOptions;
 
     xOptions.setName(X_OPTIONSFILE);


### PR DESCRIPTION
Currently, when running under Wayland, the window icon will fallback to the default Wayland icon.
Setting the desktop filename can solve this problem.
Similar to https://github.com/horsicq/XAPKDetector/pull/9